### PR TITLE
Unicode require

### DIFF
--- a/lib/unidecoder.rb
+++ b/lib/unidecoder.rb
@@ -60,17 +60,27 @@ module Unidecoder
     "#{code_group(unpacked)}.yml (line #{grouped_point(unpacked) + 2})"
   end
 
-  def define_normalize(library = nil, &block)
-    return if method_defined? :normalize
+  def define_normalize(library = nil, lib_defines = nil, &block)
+    return false if method_defined? :normalize
+
     begin
       require library if library
-      define_method(:normalize, &block)
+      if lib_defines
+        if Object.const_defined?(lib_defines)
+          define_method(:normalize, &block)
+          return true
+        end
+      else
+        define_method(:normalize, &block)
+        return true
+      end
     rescue LoadError
     end
+    return false
   end
 
-  define_normalize("unicode") {|str| Unicode.normalize_C(str)}
-  define_normalize("active_support") {|str| ActiveSupport::Multibyte::Chars.new(str).normalize(:c).to_s}
+  define_normalize("unicode", "Unicode") {|str| Unicode.normalize_C(str)}
+  define_normalize("active_support", "ActiveSupport") {|str| ActiveSupport::Multibyte::Chars.new(str).normalize(:c).to_s}
   define_normalize {|str| str}
 
   def decode_char(char)

--- a/test/unidecoder_test.rb
+++ b/test/unidecoder_test.rb
@@ -111,4 +111,15 @@ class UnidecoderTest < Test::Unit::TestCase
     assert_equal "Juergen", Unidecoder.decode("Jürgen", "ü" => "ue")
   end
 
+  def test_define_normalize_with_submodule_name_clash
+    Unidecoder.send("remove_method", :normalize)
+
+    assert_equal false, Unidecoder.define_normalize("bad_file", "WrongName") {|str| str = 'normalized' }
+    assert_equal false, Unidecoder.define_normalize("unicode", "WrongName") {|str| str = 'normalized' }
+    assert_equal true, Unidecoder.define_normalize {|str| str}
+  ensure
+    # Make sure we un-break the environment.
+    Unidecoder.define_normalize {|str| str}
+  end
+
 end


### PR DESCRIPTION
We ran into a problem while importing Unidecoder where we have load path that makes `require "unicode"` return success but to load a class other than `::Unicode`. To get around that I added a second parameter to `define_normalize` so it can verify it loaded the correct class or module.
