### PR TITLE
Fix yaml reserved words

### DIFF
--- a/lib/unidecoder/data/x12.yml
+++ b/lib/unidecoder/data/x12.yml
@@ -149,7 +149,7 @@
 - naa
 - nee
 - ne
-- no
+- 'no'
 - nwa
 - nya
 - nyu

--- a/lib/unidecoder/data/x13.yml
+++ b/lib/unidecoder/data/x13.yml
@@ -194,7 +194,7 @@
 - nah
 - ne
 - ni
-- no
+- 'no'
 - nu
 - nv
 - qua

--- a/lib/unidecoder/data/x14.yml
+++ b/lib/unidecoder/data/x14.yml
@@ -195,7 +195,7 @@
 - naai
 - ni
 - nii
-- no
+- 'no'
 - noo
 - noo
 - na

--- a/lib/unidecoder/data/x15.yml
+++ b/lib/unidecoder/data/x15.yml
@@ -185,7 +185,7 @@
 - wa
 - ne
 - ni
-- no
+- 'no'
 - na
 - ke
 - ki

--- a/lib/unidecoder/data/x16.yml
+++ b/lib/unidecoder/data/x16.yml
@@ -2,7 +2,7 @@
 - kka
 - kk
 - nu
-- no
+- 'no'
 - ne
 - nee
 - ni

--- a/lib/unidecoder/data/x30.yml
+++ b/lib/unidecoder/data/x30.yml
@@ -109,7 +109,7 @@
 - ni
 - nu
 - ne
-- no
+- 'no'
 - ha
 - ba
 - pa
@@ -205,7 +205,7 @@
 - ni
 - nu
 - ne
-- no
+- 'no'
 - ha
 - ba
 - pa

--- a/lib/unidecoder/data/x32.yml
+++ b/lib/unidecoder/data/x32.yml
@@ -231,7 +231,7 @@
 - ni
 - nu
 - ne
-- no
+- 'no'
 - ha
 - hi
 - hu

--- a/lib/unidecoder/data/xa1.yml
+++ b/lib/unidecoder/data/xa1.yml
@@ -139,7 +139,7 @@
 - nuop
 - not
 - nox
-- no
+- 'no'
 - nop
 - nex
 - ne

--- a/lib/unidecoder/data/xb1.yml
+++ b/lib/unidecoder/data/xb1.yml
@@ -119,7 +119,7 @@
 - nyet
 - nyep
 - nyeh
-- no
+- 'no'
 - nog
 - nogg
 - nogs

--- a/lib/unidecoder/data/xc6.yml
+++ b/lib/unidecoder/data/xc6.yml
@@ -26,7 +26,7 @@
 - yem
 - yeb
 - yebs
-- yes
+- 'yes'
 - yess
 - yeng
 - yej

--- a/lib/unidecoder/data/xff.yml
+++ b/lib/unidecoder/data/xff.yml
@@ -136,7 +136,7 @@
 - ni
 - nu
 - ne
-- no
+- 'no'
 - ha
 - hi
 - hu


### PR DESCRIPTION
`yes`, `no` are converted into `true`, `false` in [yaml (until 1.1)](http://yaml.org/spec/1.1/#id864510).
(There was no documentation about this in [1.2](http://yaml.org/spec/1.2/spec.html))

Therefore these characters are converted into string "true", "false".

```ruby
irb(main):022:0> "ኖᏃᓄᖺᘃのノ㋨ꆌ노".to_ascii
=> "falsefalsefalsefalsefalsefalsefalsefalsefalsefalse"
irb(main):027:0> '온'.to_ascii
=> "true"
```

I wrapped all the `yes`, `no` occurrences with brackets.
