### PR TITLE
YAML.safe_load and ruby's unicode_normalize method

### DIFF
--- a/lib/unidecoder.rb
+++ b/lib/unidecoder.rb
@@ -2,7 +2,6 @@ require "yaml"
 
 # Utilities for transliterating UTF-8 strings to ASCII.
 module Unidecoder
-
   # Contains Unicode codepoints, loading as needed from YAML files.
   CODEPOINTS = Hash.new { |h, k|
     h[k] = YAML::load_file(File.expand_path("../unidecoder/data/#{k}.yml", __FILE__))
@@ -60,18 +59,9 @@ module Unidecoder
     "#{code_group(unpacked)}.yml (line #{grouped_point(unpacked) + 2})"
   end
 
-  def define_normalize(library = nil, &block)
-    return if method_defined? :normalize
-    begin
-      require library if library
-      define_method(:normalize, &block)
-    rescue LoadError
-    end
+  def normalize(str)
+    str.unicode_normalize
   end
-
-  define_normalize("unicode") {|str| Unicode.normalize_C(str)}
-  define_normalize("active_support") {|str| ActiveSupport::Multibyte::Chars.new(str).normalize(:c).to_s}
-  define_normalize {|str| str}
 
   def decode_char(char)
     unpacked = char.unpack("U")[0]

--- a/lib/unidecoder.rb
+++ b/lib/unidecoder.rb
@@ -4,7 +4,7 @@ require "yaml"
 module Unidecoder
   # Contains Unicode codepoints, loading as needed from YAML files.
   CODEPOINTS = Hash.new { |h, k|
-    h[k] = YAML::load_file(File.expand_path("../unidecoder/data/#{k}.yml", __FILE__))
+    h[k] = YAML.safe_load(File.read(File.expand_path("../unidecoder/data/#{k}.yml", __FILE__)))
   } unless defined?(CODEPOINTS)
 
   module StringExtensions


### PR DESCRIPTION
introduced in ruby 2.2: https://www.honeybadger.io/blog/ruby-unicode-normalization/ (2.3 just got EOL)

about the safe_load, if doesn't change anything as it's just data files, I just don't like "eval"s in my code :)

also this doesn't work in rails 6 at least because of the ActiveSupport normalize method that got renamed